### PR TITLE
Add Docker deployment support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,16 +1,11 @@
 stages:
-    - build
     - deploy
 
-before_script:
-    - cd ./MEE7-Discord-Bot
-
-build:
-    stage: build
-    script:
-        - docker build -t meesevenimage -f Dockerfile .
-
 deploy:
+    image:
+        name: docker/compose:1.24.1
+        entrypoint: ["/bin/sh", "-c"]
     stage: deploy
     script: 
-        - docker run meesevenimage
+        - docker-compose build
+        - BotToken=$BOT_TOKEN docker-compose up -d

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2
+
 WORKDIR /app
+COPY MEE7-Discord-Bot .
 
+RUN mkdir dist
 RUN dotnet restore
+RUN dotnet build -c Release
 
-COPY app/bin/Release/netcoreapp2.2/publish/ app/
-RUN dotnet publish -c Release -o out
-
-ENTRYPOINT ["dotnet", "app/MEE7.dll"]
+CMD ["dotnet", "run", "-c", "Release"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:2.2
 WORKDIR /app
 COPY MEE7-Discord-Bot .
 
-RUN mkdir dist
 RUN dotnet restore
 RUN dotnet build -c Release
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3"
+
+services:
+  mee7:
+    build: .
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,5 @@ services:
   mee7:
     build: .
     restart: always
+    environment:
+      - BotToken


### PR DESCRIPTION
This PR fixes the `Dockerfile` and updates the GitLab CI pipeline so that it correctly builds and runs the bot. Additionally, a `docker-compose.yml` is added for convenience.

The only remaining step to get the application up and running is to add the secret variable `BOT_TOKEN` to the project's GitLab configuration.