### PR TITLE
Add generic CI build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '3.1.x'
+      - name: Build project
+        run: dotnet build MEE7-Discord-Bot

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Discord-Bot
 
+[![Build](https://github.com/niklasCarstensen/Discord-Bot/actions/workflows/build.yml/badge.svg)](https://github.com/niklasCarstensen/Discord-Bot/actions/workflows/build.yml)
+[![Deploy](https://github.com/niklasCarstensen/Discord-Bot/actions/workflows/deploy.yml/badge.svg)](https://github.com/niklasCarstensen/Discord-Bot/actions/workflows/deploy.yml)
+
 This is quite a large discord bot with a weird name. The commands are split into two groups, simple commands that entirely depend on side effects and edit commands that get data from other edit commands and output data that other edit commands can use. Those pipes of edit comands can for example be used for image editing.
 
 Example pipe for a mandelbrot zoom with rotating colors: `$- for(i:0:20:0.2) { mandelbrot(%i, 1.01:0.28, 100) } > foreach(i:0:360) { rotateColors(%i) }` resulting in this gif:


### PR DESCRIPTION
This PR adds a workflow that builds the project in CI, along with CI badges in the README.